### PR TITLE
Add support for EnforceLocalDestination and DefaultDestination

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,15 @@
 Revision history for Apache::AuthCookie
 
 {{$NEXT}}
+   - Add optional support for enforcing a local destination, like so:
+
+        PerlSetVar MyAuthEnforceLocalDestination 1
+
+   - Add optional support for specifying a default destination when the login
+     form's destination argument is unspecified or invalid (including
+     non-local if local destinations are enforced), like this:
+
+        PerlSetVar MyAuthDefaultDestination /protected/user/
 
 3.28  2019-11-19
    - Add support for SameSite cookie property (can be strict/lax).

--- a/lib/Apache2/AuthCookie.pm
+++ b/lib/Apache2/AuthCookie.pm
@@ -190,6 +190,14 @@ MethodHandlers, Authen, and Authz compiled in.
  # optional: enable decoding of httpd.conf "Requires" directives
  PerlSetVar WhatEverRequiresEncoding UTF-8
 
+ # optional: enforce that the destination argument from the login form is
+ # local to the server
+ PerlSetVar WhatEverEnforceLocalDestination 1
+
+ # optional: specify a default destination for when the destination argument
+ # of the login form is invalid or unspecified
+ PerlSetVar WhatEverDefaultDestination /protected/user/
+
  # These documents require user to be logged in.
  <Location /protected>
   AuthType Sample::Apache2::AuthCookieHandler

--- a/t/conf/extra.conf.in
+++ b/t/conf/extra.conf.in
@@ -23,6 +23,8 @@ PerlSetVar AuthCookieDebug 3
 PerlSetVar WhatEverCookieName Sample::AuthCookieHandler_WhatEver
 PerlSetVar WhatEverEncoding UTF-8
 PerlSetVar WhatEverRequiresEncoding UTF-8
+PerlSetVar WhatEverDefaultDestination /docs/protected/index.html
+PerlSetVar WhatEverEnforceLocalDestination On
 
 <Directory @ServerRoot@>
   AllowOverride All


### PR DESCRIPTION
Refer to issue #12 for context.

This PR adds support for `EnforceLocalDestination` and `DefaultDestination` authentication options. The former enforces that the destination argument from the login form is always local to the server. The latter allows you specify a default destination for when the destination argument of the login form is invalid or unspecified.