### PR TITLE
small typo in documentation

### DIFF
--- a/lib/Apache2_4/AuthCookie.pm
+++ b/lib/Apache2_4/AuthCookie.pm
@@ -553,7 +553,7 @@ saved login.  I use a database to store the session key and retrieve it later.
 
 I upgraded to Apache 2.4 and now AuthCookie doesn't work!
 
-Apache 2.4 radically changed the authenciation and authorization API.  You will
+Apache 2.4 radically changed the authentication and authorization API.  You will
 need to port your AuthCookie subclass over to the Apache 2.4 API.  See the POD
 documentation in L<README.apache-2.4> for more information, but the quick
 rundown is you need to:


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Apache-AuthCookie.
We thought you might be interested in it too.

    Description: small typo in documentation
     authenciation â authentication
    Author: Damyan Ivanov <dmn@debian.org>


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libapache2-authcookie-perl/raw/master/debian/patches/doc-typo.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
