### PR TITLE
Update mod_perl2 version number requirement to silence warning with Perl 5.40

### DIFF
--- a/lib/Apache2/AuthCookie/Base.pm
+++ b/lib/Apache2/AuthCookie/Base.pm
@@ -3,7 +3,7 @@ package Apache2::AuthCookie::Base;
 # ABSTRACT: Common Methods Shared by Apache2 and Apache2_4 AuthCookie Subclasses.
 
 use strict;
-use mod_perl2 '1.99022';
+use mod_perl2 1.99022;
 use Carp;
 
 use Apache::AuthCookie::Util qw(is_blank is_local_destination);


### PR DESCRIPTION
This pull request addresses issue #17.

Using the module with Perl 5.40 would cause the following warning message:
```
$ perl -we 'use Apache2::AuthCookie'
Attempt to call undefined import method with arguments ("1.99022") via package "mod_perl2" (Perhaps you forgot to load the package?) at /usr/share/perl5/Apache2/AuthCookie/Base.pm line 6.
```
This PR will silence that warning, and I hope it is backwards compatible.